### PR TITLE
add basic support for arm64

### DIFF
--- a/create-initrd
+++ b/create-initrd
@@ -102,8 +102,10 @@ if [ -x /usr/bin/busybox-static ]; then
 	ln -s busybox chroot
 	popd
 else
-	for lib in ld-2.22.so ld-linux.so.2; do
-		cp /lib/${lib} lib64/
+	LD_2=`rpm -ql glibc | grep ld-2`
+	LD_LINUX=`rpm -ql glibc | grep ld-linux`
+	for lib in ${LD_2} ${LD_LINUX}; do
+		cp ${lib} lib64/
 	done
 
 	for prog in ${PROGRAMS[@]}; do

--- a/kernel-ci
+++ b/kernel-ci
@@ -68,6 +68,15 @@ while getopts "a:dk:i:r:t:h?" opt; do
 	esac
 done
 
+# architecture description of qemu and kernel can be different
+if [ "$ARCH" == "aarch64" ]; then
+	KARCH="arm64"
+	KIMG="Image"
+else
+	KARCH="$ARCH"
+	KIMG="bzImage"
+fi
+
 if [ x"$KERNELDIR" == "x" ]; then
 	pr_err "Kernel directory not set"
 	echo ""
@@ -89,8 +98,8 @@ pr_debug "Using JeOS image ${IMAGE}"
 pr_debug "Creating initrd"
 ./create-initrd -k ${KERNELDIR} ${ROOT:+-r $ROOT} -m "$MODULES" > /dev/null
 pr_debug "Lunching VM"
-./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} $DEBUG \
-	-k $KERNELDIR/arch/x86_64/boot/bzImage -i initrd.img \
+./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} ${DEBUG} \
+	-k $KERNELDIR/arch/$KARCH/boot/$KIMG -i initrd.img \
 	-t $TIMEOUT 2>&1 | tee $LOGFILE
 if grep -e "$SUCCESS_MARKER" $LOGFILE; then
 	echo "SUCCESS"

--- a/kernel-ci
+++ b/kernel-ci
@@ -37,6 +37,7 @@ TIMEOUT=180
 LOGFILE=""
 RC=1
 SUCCESS_MARKER="login:"
+DEBUG=""
 
 trap cleanup EXIT
 
@@ -46,7 +47,7 @@ while getopts "a:dk:i:r:t:h?" opt; do
 			ARCH=$OPTARG
 			;;
 		d)
-			DEBUG=1
+			DEBUG="-d"
 			;;
 		k)
 			KERNELDIR=$OPTARG
@@ -88,15 +89,9 @@ pr_debug "Using JeOS image ${IMAGE}"
 pr_debug "Creating initrd"
 ./create-initrd -k ${KERNELDIR} ${ROOT:+-r $ROOT} -m "$MODULES" > /dev/null
 pr_debug "Lunching VM"
-if [ $DEBUG -gt 0 ]; then
-./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} -d \
+./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} $DEBUG \
 	-k $KERNELDIR/arch/x86_64/boot/bzImage -i initrd.img \
 	-t $TIMEOUT 2>&1 | tee $LOGFILE
-else
-./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} \
-	-k $KERNELDIR/arch/x86_64/boot/bzImage -i initrd.img \
-	-t $TIMEOUT 2>&1 | tee $LOGFILE
-fi
 if grep -e "$SUCCESS_MARKER" $LOGFILE; then
 	echo "SUCCESS"
 	RC=0

--- a/kernel-ci
+++ b/kernel-ci
@@ -50,10 +50,10 @@ while getopts "a:dk:i:r:t:h?" opt; do
 			DEBUG="-d"
 			;;
 		k)
-			KERNELDIR=$OPTARG
+			KERNELDIR=`realpath $OPTARG`
 			;;
 		i)
-			MASTER=$OPTARG
+			MASTER=`realpath $OPTARG`
 			;;
 		r)
 			ROOT=$OPTARG

--- a/lib.sh
+++ b/lib.sh
@@ -19,7 +19,7 @@ pr_err()
 
 pr_debug()
 {
-	if [ $DEBUG == 1 ]; then
+	if [ "$DEBUG" == "-d" ]; then
 		echo "[DEBUG] $@"
 	fi
 }

--- a/vm
+++ b/vm
@@ -36,7 +36,7 @@ while getopts "da:k:i:r:hR:t:" opt; do
 			ARCH=$OPTARG
 			;;
 		d)
-			DEBUG=1
+			DEBUG="-d"
 			;;
 		k)
 			KERNEL=$OPTARG
@@ -80,7 +80,7 @@ fi
 
 QUIET=quiet
 
-if [ $DEBUG -gt 0 ]; then
+if [ "$DEBUG" == "-d" ]; then
 	QUIET=debug
 fi
 

--- a/vm
+++ b/vm
@@ -84,11 +84,25 @@ if [ "$DEBUG" == "-d" ]; then
 	QUIET=debug
 fi
 
+
+
+if [ "$ARCH" == "aarch64" ]; then
+	QEMU_EXTRA="-machine virt -cpu host -bios /usr/share/qemu/qemu-uefi-aarch64.bin -enable-kvm"
+	QEMU_DEVICE="-device virtio-blk-pci,scsi=off,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
+	CONSOLE="ttyAMA0"
+else
+	QEMU_EXTRA=""
+	QEMU_DEVICE="-device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
+	CONSOLE="ttyS0"
+fi
+
 QEMU_CMD=(
 	"$QEMU$ARCH"
 
+	$QEMU_EXTRA
+
 	# Disk
-	-device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1
+	$QEMU_DEVICE
 	-drive file="${ROOTFS}",if=none,id=drive-virtio-disk0 -snapshot
 
 	# Serial output
@@ -98,7 +112,7 @@ QEMU_CMD=(
 	-smp 2 -m 1024
 
 	# Kernel & initrd
-	-append 'root='${ROOT}' ro console=ttyS0 '${QUIET}' rdinit=/bin/init'
+	-append 'root='${ROOT}' ro console=${CONSOLE} "${QUIET}" rdinit=/bin/init'
 	-kernel "$KERNEL"
 	-initrd "$INITRD"
 )


### PR DESCRIPTION
This patches add basic support for arm64.

It starts qemu, but fails to mount the initrd.img as the parameter /dev/vda3 is not correct.
I will fix this in subsequent patch(es).

Regards,
Matthias
