### PR TITLE
vm: Use single quotes around variables so they get expanded

### DIFF
--- a/create-initrd
+++ b/create-initrd
@@ -25,8 +25,10 @@ copy_libs_for_prog()
 
 usage()
 {
-	echo "Usage: $1 [-k kdir ] [-m '<module[ <module>][...]'] [-r root]" >&2
+	echo "Usage: $1 [-f '<file[ <file>][...]'] [-k kdir ] [-m '<module[ <module>][...]'] [-r root]" >&2
 	echo "" >&2
+	echo "  -f Space separated list of files to include in initrd" >&2
+	echo "     image." >&2
 	echo "  -k Directory having the kernel sources." >&2
 	echo "  -m Space separated list of kernel modules to include" >&2
 	echo "     in initrd image." >&2
@@ -35,8 +37,11 @@ usage()
 }
 
 program=$(basename $0)
-while getopts "k:m:r:?" flag; do
+while getopts "f:k:m:r:?" flag; do
 	case ${flag} in
+		f)
+			FILES=${OPTARG}
+			;;
 		k)
 			KDIR=${OPTARG}
 			;;
@@ -61,7 +66,7 @@ if [ x"$ROOT" == "x" ]; then
 fi
 
 rm -rf initrd
-mkdir -p initrd/{bin,dev,etc,lib/modules,lib64,proc,sys,sysroot}
+mkdir -p initrd/{bin,dev,etc,lib/modules,lib64,proc,sys,sysroot,root}
 pushd initrd
 ln -s bin sbin
 pushd bin
@@ -127,6 +132,12 @@ if [ x"$KDIR" != "x" ]; then
 	fi
 	for mod in ${MODULES}; do
 		find $KDIR -name "${mod}" | xargs cp -t lib/modules/
+	done
+fi
+
+if [ "x$FILES" != "x" ]; then
+	for file in ${FILES}; do
+		cp ${file} root/
 	done
 fi
 

--- a/create-initrd
+++ b/create-initrd
@@ -5,7 +5,7 @@
 # This file is part of the kernel-ci project and licensed under the GNU GPLv2
 #
 
-PROGRAMS=('sh' 'cat' 'chroot' 'echo' 'insmod' 'mount' 'sleep')
+DEFPROGRAMS=('sh' 'cat' 'chroot' 'echo' 'insmod' 'mount' 'sleep')
 #MODULES=('efivarfs.ko' 'mcb.ko' 'mcb-pci.ko')
 
 DEFROOT="/dev/vda3"
@@ -32,12 +32,14 @@ usage()
 	echo "  -k Directory having the kernel sources." >&2
 	echo "  -m Space separated list of kernel modules to include" >&2
 	echo "     in initrd image." >&2
+	echo "  -p Space separated list of programs to include in" >&2
+	echo "     initrd image." >&2
 	echo "  -r root= kernel option (default $DEFROOT)."  >&2
 	exit 1
 }
 
 program=$(basename $0)
-while getopts "f:k:m:r:?" flag; do
+while getopts "f:k:m:p:r:?" flag; do
 	case ${flag} in
 		f)
 			FILES=${OPTARG}
@@ -47,6 +49,9 @@ while getopts "f:k:m:r:?" flag; do
 			;;
 		m)
 			MODULES=${OPTARG}
+			;;
+		p)
+			PROGRAMS=${OPTARG}
 			;;
 		r)
 			ROOT=${OPTARG}
@@ -63,6 +68,10 @@ done
 
 if [ x"$ROOT" == "x" ]; then
 	ROOT=$DEFROOT
+fi
+
+if [ x"$PROGRAMS" == "x" ]; then
+	PROGRAMS=$DEFPROGRAMS
 fi
 
 rm -rf initrd

--- a/create-initrd
+++ b/create-initrd
@@ -25,10 +25,11 @@ copy_libs_for_prog()
 
 usage()
 {
-	echo "Usage: $1 [-f '<file[ <file>][...]'] [-k kdir ] [-m '<module[ <module>][...]'] [-r root]" >&2
+	echo "Usage: $1 [-f '<file[ <file>][...]'] [-i init] [-k kdir ] [-m '<module[ <module>][...]'] [-r root]" >&2
 	echo "" >&2
 	echo "  -f Space separated list of files to include in initrd" >&2
 	echo "     image." >&2
+	echo "  -i bin/init source." >&2
 	echo "  -k Directory having the kernel sources." >&2
 	echo "  -m Space separated list of kernel modules to include" >&2
 	echo "     in initrd image." >&2
@@ -39,10 +40,13 @@ usage()
 }
 
 program=$(basename $0)
-while getopts "f:k:m:p:r:?" flag; do
+while getopts "f:i:k:m:p:r:?" flag; do
 	case ${flag} in
 		f)
 			FILES=${OPTARG}
+			;;
+		i)
+			INIT_SRC=${OPTARG}
 			;;
 		k)
 			KDIR=${OPTARG}
@@ -81,14 +85,15 @@ ln -s bin sbin
 pushd bin
 popd
 
-echo "#!/bin/sh" >> bin/init
+if [ x"$INIT_SRC" == "x" ]; then
+	echo "#!/bin/sh" >> bin/init
 
-for mod in ${MODULES}; do
-	echo "echo \"Loading ${mod}\"" >> bin/init
-	echo "insmod /lib/modules/${mod}" >> bin/init
-done
+	for mod in ${MODULES}; do
+		echo "echo \"Loading ${mod}\"" >> bin/init
+		echo "insmod /lib/modules/${mod}" >> bin/init
+	done
 
-cat >> bin/init << __EOF__
+	cat >> bin/init << __EOF__
 
 echo "Mounting /proc, /dev and /sys"
 mount -t proc /proc /proc
@@ -103,6 +108,9 @@ cd /sysroot
 exec chroot . sh -c 'exec /sbin/init'
 
 __EOF__
+else
+	cp ${INIT_SRC} bin/init
+fi
 
 chmod 755 bin/init
 

--- a/kernel-ci
+++ b/kernel-ci
@@ -85,21 +85,19 @@ if [ x"$KERNELDIR" == "x" ]; then
 	exit 1
 fi
 
-if [ x"$MASTER" == "x" ]; then
-	pr_err "HDD Image not set"
-	echo ""
-	usage
-	exit 1
+IMAGE_OPTS=""
+if [ x"$MASTER" != "x" ]; then
+	IMAGE=$MASTER.$$
+	IMAGE_OPTS="-r ${IMAGE}"
 fi
 
-IMAGE=$MASTER.$$
 LOGFILE=kernel-ci.$$.log
 cp ${MASTER} ${IMAGE}
 pr_debug "Using JeOS image ${IMAGE}"
 pr_debug "Creating initrd"
 ${SRC_ROOT}/create-initrd -k ${KERNELDIR} ${ROOT:+-r $ROOT} -m "$MODULES" > /dev/null
 pr_debug "Lunching VM"
-${SRC_ROOT}/vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} ${DEBUG} \
+${SRC_ROOT}/vm -a ${ARCH} ${IMAGE_OPTS} ${ROOT:+-R $ROOT} ${DEBUG} \
 	-k $KERNELDIR/arch/$KARCH/boot/$KIMG -i initrd.img \
 	-t $TIMEOUT 2>&1 | tee $LOGFILE
 if grep -e "$SUCCESS_MARKER" $LOGFILE; then

--- a/kernel-ci
+++ b/kernel-ci
@@ -7,7 +7,8 @@
 
 set -o nounset
 
-source ./lib.sh
+SRC_ROOT=$(dirname ${BASH_SOURCE[0]})
+source ${SRC_ROOT}/lib.sh
 
 cleanup() 
 {
@@ -96,9 +97,9 @@ LOGFILE=kernel-ci.$$.log
 cp ${MASTER} ${IMAGE}
 pr_debug "Using JeOS image ${IMAGE}"
 pr_debug "Creating initrd"
-./create-initrd -k ${KERNELDIR} ${ROOT:+-r $ROOT} -m "$MODULES" > /dev/null
+${SRC_ROOT}/create-initrd -k ${KERNELDIR} ${ROOT:+-r $ROOT} -m "$MODULES" > /dev/null
 pr_debug "Lunching VM"
-./vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} ${DEBUG} \
+${SRC_ROOT}/vm -a ${ARCH} -r ${IMAGE} ${ROOT:+-R $ROOT} ${DEBUG} \
 	-k $KERNELDIR/arch/$KARCH/boot/$KIMG -i initrd.img \
 	-t $TIMEOUT 2>&1 | tee $LOGFILE
 if grep -e "$SUCCESS_MARKER" $LOGFILE; then

--- a/vm
+++ b/vm
@@ -6,7 +6,8 @@
 #
 set -o nounset
 
-source ./lib.sh
+SRC_ROOT=$(dirname ${BASH_SOURCE[0]})
+source ${SRC_ROOT}/lib.sh
 
 QEMU="qemu-system-"
 ARCH="x86_64"

--- a/vm
+++ b/vm
@@ -112,7 +112,7 @@ QEMU_CMD=(
 	-smp 2 -m 1024
 
 	# Kernel & initrd
-	-append 'root='${ROOT}' ro console=${CONSOLE} "${QUIET}" rdinit=/bin/init'
+	-append 'root='${ROOT}' ro console='${CONSOLE}' '${QUIET}' rdinit=/bin/init'
 	-kernel "$KERNEL"
 	-initrd "$INITRD"
 )

--- a/vm
+++ b/vm
@@ -121,7 +121,7 @@ QEMU_CMD=(
 	-smp 2 -m 1024
 
 	# Kernel & initrd
-	-append 'root='${ROOT}' ro console='${CONSOLE}' '${QUIET}' rdinit=/bin/init'
+	-append 'root='${ROOT}' ro console='${CONSOLE}' '${QUIET}' rdinit=/bin/init crashkernel=64M'
 	-kernel "$KERNEL"
 	-initrd "$INITRD"
 )

--- a/vm
+++ b/vm
@@ -16,22 +16,24 @@ INITRD=""
 ROOTFS=""
 ROOT="/dev/vda3"
 TIMEOUT=""
+QEMUARGS=""
 
 # TODO Add networking
 
 usage()
 {
 	prog=$(basename $0)
-	echo "$prog [-a arch] [-d] [-r rootfs] [-R root] -k <kernel> -i <initrd>" >&2
+	echo "$prog [-a arch] [-d] [-r rootfs] [-R root] -k <kernel> -i <initrd> [-q qemuargs]" >&2
 	echo "  -a arch         Architecture for QEMU." >&2
 	echo "  -d              Enable debug output." >&2
 	echo "  -r rootfs       Rootfs image to use." >&2
 	echo "  -R root         root= kernel cmdline option" >&2
 	echo "  -k kernel       kernel image to use." >&2
 	echo "  -i initrd       initrd image to use." >&2
+	echo "  -q qemuargs	Extra qemu arguments." >&2
 }
 
-while getopts "da:k:i:r:hR:t:" opt; do
+while getopts "da:k:i:r:hR:t:q:" opt; do
 	case ${opt} in
 		a)
 			ARCH=$OPTARG
@@ -53,6 +55,9 @@ while getopts "da:k:i:r:hR:t:" opt; do
 			;;
 		t)
 			TIMEOUT=$OPTARG
+			;;
+		q)
+			QEMUARGS=$OPTARG
 			;;
 		h)
 			usage
@@ -96,7 +101,7 @@ if [ "$ARCH" == "aarch64" ]; then
 	QEMU_EXTRA="-machine virt -cpu host -bios /usr/share/qemu/qemu-uefi-aarch64.bin -enable-kvm"
 	CONSOLE="ttyAMA0"
 else
-	QEMU_EXTRA=""
+	QEMU_EXTRA="$QEMUARGS"
 	CONSOLE="ttyS0"
 fi
 

--- a/vm
+++ b/vm
@@ -67,10 +67,15 @@ if [ x"$KERNEL" == "x" ]; then
 	exit 1
 fi
 
-if [ x"$ROOTFS" == "x" ]; then
-	pr_err "No rootfs option given"
-	usage
-	exit 1
+QEMU_ROOTFS=""
+QEMU_DEVICE=""
+if [ x"$ROOTFS" != "x" ]; then
+	QEMU_ROOTFS="-drive file="${ROOTFS}",if=none,id=drive-virtio-disk0 -snapshot"
+	if [ "$ARCH" == "aarch64" ]; then
+		QEMU_DEVICE="-device virtio-blk-pci,scsi=off,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
+	else
+		QEMU_DEVICE="-device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
+	fi
 fi
 
 if [ x"$INITRD" == "x" ]; then
@@ -89,11 +94,9 @@ fi
 
 if [ "$ARCH" == "aarch64" ]; then
 	QEMU_EXTRA="-machine virt -cpu host -bios /usr/share/qemu/qemu-uefi-aarch64.bin -enable-kvm"
-	QEMU_DEVICE="-device virtio-blk-pci,scsi=off,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
 	CONSOLE="ttyAMA0"
 else
 	QEMU_EXTRA=""
-	QEMU_DEVICE="-device virtio-blk-pci,scsi=off,bus=pci.0,addr=0x5,drive=drive-virtio-disk0,id=virtio-disk0,bootindex=1"
 	CONSOLE="ttyS0"
 fi
 
@@ -104,7 +107,7 @@ QEMU_CMD=(
 
 	# Disk
 	$QEMU_DEVICE
-	-drive file="${ROOTFS}",if=none,id=drive-virtio-disk0 -snapshot
+	$QEMU_ROOTFS
 
 	# Serial output
 	-serial stdio -monitor none -nographic


### PR DESCRIPTION
If we want to allow ${CONSOLE} and ${QUIET} to be expanded to the
assigned values we need to use single quotes around them, otherwise
the string gets inserted literally, e.g.

  root=/dev/vda ro console=${CONSOLE} "${QUIET}" rdinit=/bin/init

I noticed this issue when nothing was being printed on the serial
console when booting a test kernel.

Signed-off-by: Matt Fleming matt@codeblueprint.co.uk
