### PR TITLE
create-initrd: Fix syntax error

### DIFF
--- a/create-initrd
+++ b/create-initrd
@@ -58,6 +58,7 @@ while getopts "f:i:h:k:m:p:o:r:?" flag; do
 			;;
 		p)
 			PROGRAMS=${OPTARG}
+			;;
 		o)
 			O=${OPTARG}
 			;;


### PR DESCRIPTION
create-initrd: line 61: syntax error near unexpected token `)'
create-initrd: line 61:`       o)'

Signed-off-by: Michal Marek mmarek@suse.com
